### PR TITLE
Update symfony/string dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "license": "proprietary",
   "require": {
     "php": "*",
-    "symfony/string": "^5.1",
+    "symfony/string": "^5.1 || ^6.0 || ^7.0",
     "ext-json": "*"
   },
   "require-dev": {


### PR DESCRIPTION
I'm not sure where the symfony/string package is used exactly in your repo, but the dependency on symfony/string 5.x is blocking updates in my installation, so here's a PR that should fix that.